### PR TITLE
Update Kotlin version and Jetpack Compose compiler

### DIFF
--- a/flickr/api/build.gradle.kts
+++ b/flickr/api/build.gradle.kts
@@ -9,7 +9,13 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     kotlinOptions {
+        jvmTarget = "1.8"
         moduleName = "cz.drekorian.android.flickr.flickr.api"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/flickr/impl/build.gradle.kts
+++ b/flickr/impl/build.gradle.kts
@@ -9,10 +9,16 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     kotlinOptions {
+        jvmTarget = "1.8"
         moduleName = "cz.drekorian.android.flickr.flickr.impl"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
         )
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ minSdk = "21"
 targetSdk = "33"
 
 # Kotlin
-kotlin = "1.7.10"
+kotlin = "1.9.23"
 
 # Third party libraries
 
@@ -20,7 +20,7 @@ androidxLifecycle = "2.5.1"
 androidxNavigation = "2.5.1"
 coil = "2.2.0"
 compose = "1.2.1"
-composeCompiler = "1.3.0-rc02"
+composeCompiler = "1.5.12"
 composeMaterial3 = "1.0.0-beta01"
 koin = "3.2.0"
 kotlinxCoroutinesAndroid = "1.6.4"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -8,7 +8,13 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     kotlinOptions {
+        jvmTarget = "1.8"
         moduleName = "cz.drekorian.android.flickr.shared"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
Updates Kotlin to version `1.9.23` and Jetpack Compose compiler to version `1.5.12`.