### PR TITLE
Update SDK targeting

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 
 # Android SDK
 agp = "8.3.0"
-buildTools = "33.0.0"
-compileSdk = "33"
+buildTools = "34.0.0"
+compileSdk = "34"
 minSdk = "21"
-targetSdk = "33"
+targetSdk = "34"
 
 # Kotlin
 kotlin = "1.9.23"


### PR DESCRIPTION
Upgrades `buildTools` to `34.0.0`, `compileSdk` to `34` and `targetSdk` to `34`.